### PR TITLE
fix arity for c++20

### DIFF
--- a/include/utl/struct/arity.h
+++ b/include/utl/struct/arity.h
@@ -46,7 +46,7 @@ struct is_paren_constructible_;
 
 template <typename T, size_t... I>
 struct is_paren_constructible_<T, std::index_sequence<I...>>
-    : std::is_constructible<T, decltype(_<I>)...> {};
+    : std::is_trivially_constructible<T, decltype(_<I>)...> {};
 
 template <typename T, size_t N>
 constexpr auto is_paren_constructible()


### PR DESCRIPTION
As C++20 now allows parenthesis for aggregate initialization is_paren_constructible has to be adjusted. Moving from is_constructible to is_trivially_constructible should retain the intended purpose and work also in C++20.