### PR TITLE
move str[] array into log struct

### DIFF
--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -21,7 +21,7 @@
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #define uLOG(lvl)                                          \
-  utl::log() << "[" << utl::log::str[lvl] << "]"                \
+  utl::log() << "[" << utl::log::str[lvl] << "]"           \
              << "[" << utl::time() << "]"                  \
              << "[" << FILE_NAME << ":" << __LINE__ << "]" \
              << " "
@@ -44,7 +44,7 @@ struct log {
   }
 
   ~log() { std::clog << std::endl; }
-  
+
   static constexpr const char* const str[]{"emrg", "alrt", "crit", "erro",
                                            "warn", "note", "info", "debg"};
 };

--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -21,7 +21,7 @@
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #define uLOG(lvl)                                          \
-  utl::log() << "[" << utl::str[lvl] << "]"                \
+  utl::log() << "[" << utl::log::str[lvl] << "]"                \
              << "[" << utl::time() << "]"                  \
              << "[" << FILE_NAME << ":" << __LINE__ << "]" \
              << " "
@@ -44,12 +44,14 @@ struct log {
   }
 
   ~log() { std::clog << std::endl; }
+  
+  static constexpr const char* const str[]{"emrg", "alrt", "crit", "erro",
+                                           "warn", "note", "info", "debg"};
 };
 
 enum log_level { emrg, alrt, crit, err, warn, notice, info, debug };
 
-static const char* const str[]{"emrg", "alrt", "crit", "erro",
-                               "warn", "note", "info", "debg"};
+
 
 inline std::string time(time_t const t) {
   char buf[sizeof "2011-10-08t07:07:09z-0430"];

--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -51,8 +51,6 @@ struct log {
 
 enum log_level { emrg, alrt, crit, err, warn, notice, info, debug };
 
-
-
 inline std::string time(time_t const t) {
   char buf[sizeof "2011-10-08t07:07:09z-0430"];
   struct tm result {};


### PR DESCRIPTION
avoids shadowing with parameters also named "str" in the utl library