### PR TITLE
Fixing Windows build by disabling TEST(init_from) with MSVC

### DIFF
--- a/test/init_from_test.cc
+++ b/test/init_from_test.cc
@@ -14,6 +14,7 @@ struct b {
   int y_;
 };
 
+#ifndef _MSC_VER  // This use case does not work with MSVC
 TEST(init_from, init_from) {
   struct test {};
 
@@ -55,3 +56,4 @@ TEST(init_from, init_from) {
   auto tgt1 = utl::init_from<a>(src);
   EXPECT_EQ(tgt1->str_, src.str_.get());
 };
+#endif


### PR DESCRIPTION
The Windows build has been broken since commit https://github.com/motis-project/utl/commit/36a7766fdf91152d13d21ef20c1c5c267e8773f5

This PR aims to fix it by getting rid of the `init_from()` as this function is not used in any repository now.