### PR TITLE
Docs: minor fixup - inserting API details

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,16 @@ utl::info("MyCtx", "Message").attrs({{"key1", "value1"}, {"key2", "value2"}});
 ```
 
 ### API details
-:::{doxygenfunction} utl::log
+:::{doxygenstruct} utl::log
+:::
+
+:::{doxygenstruct} utl::debug
+:::
+
+:::{doxygenstruct} utl::info
+:::
+
+:::{doxygenstruct} utl::error
 :::
 
 :::{note}

--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -45,7 +45,7 @@ inline std::string now() {
   return ss.str();
 }
 
-/// Produce a new log line at the given `level`, with the given message
+/// Produce a new log line at the given `level`.
 template <log_level LogLevel, typename... Args>
 struct log {
   log(const char* ctx, fmt::format_string<Args...> fmt_str,
@@ -91,16 +91,19 @@ struct log {
   std::initializer_list<std::pair<std::string_view, std::string_view> > attrs_;
 };
 
+/// Produce a new DEBUG log line
 template <typename... Args>
 struct debug : public log<log_level::debug, Args...> {
   using log<log_level::debug, Args...>::log;
 };
 
+/// Produce a new INFO log line
 template <typename... Args>
 struct info : public log<log_level::info, Args...> {
   using log<log_level::info, Args...>::log;
 };
 
+/// Produce a new ERROR log line
 template <typename... Args>
 struct error : public log<log_level::error, Args...> {
   using log<log_level::error, Args...>::log;


### PR DESCRIPTION
Fix this:
![image](https://github.com/user-attachments/assets/b0432f73-4ec7-423b-86a0-cd683477bebd)

Into this:
![image](https://github.com/user-attachments/assets/b1c8254b-3f60-4c68-8dc3-0040049a1129)

**Note**: if in the end the `Doxygen` + `breathe` setup does not bring up much added value,
in regards to the concerns expressed in https://github.com/motis-project/utl/pull/25#issuecomment-2592746379,
feel free to get rid of it.
Maybe we can give it a few weeks / months to evaluate the benefit.
AMHA the Markdown-based Sphinx documentation is the most valuable part of the generated documentation.