### PR TITLE
Docs: adding a link to the source file on GitHub

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,3 +45,23 @@ breathe_default_project = 'utl'
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 html_logo = './motis-logo.svg'
+html_theme_options = {
+    'style_external_links': True,
+}
+
+from pathlib import Path
+from docutils import nodes
+from breathe.renderer.sphinxrenderer import SphinxRenderer
+
+URL_TEMPLATE = "https://github.com/motis-project/utl/blob/master/{file_path}#L{line}"
+REPO_ROOT_DIR = Path(__file__).parent.parent
+
+def create_doxygen_target(self, node):
+    loc = node.location
+    file_path = loc.file[len(str(REPO_ROOT_DIR))+1:]
+    url = URL_TEMPLATE.format(file_path=file_path, line=loc.line)
+    title = f"{file_path} on line {loc.line}"
+    return [nodes.reference("", "", refuri=url, reftitle=title)]
+
+# Monkey patching this method:
+SphinxRenderer.create_doxygen_target = create_doxygen_target

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,15 +46,23 @@ utl::info("MyCtx", "Message").attrs({{"key1", "value1"}, {"key2", "value2"}});
 
 ### API details
 :::{doxygenstruct} utl::log
+:no-link:
+:members:
 :::
 
 :::{doxygenstruct} utl::debug
+:no-link:
+:members:
 :::
 
 :::{doxygenstruct} utl::info
+:no-link:
+:members:
 :::
 
 :::{doxygenstruct} utl::error
+:no-link:
+:members:
 :::
 
 :::{note}

--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -78,6 +78,7 @@ struct log {
     }
   }
 
+  /// Add key-values metadata
   void attrs(
       std::initializer_list<std::pair<std::string_view, std::string_view> >&&
           attrs) {


### PR DESCRIPTION
I just had fun playing with `breathe` & `Sphinx` code in order to insert links to source files on GitHub.

This feature is currently missing from `breathe`.
The monkey-patching used in this PR is not quite clean,
but I it's a starting point to suggest to add this feature in `breathe`.

## Preview
![image](https://github.com/user-attachments/assets/bf781e2a-ddc1-42b7-82fd-5312bce70f40)
