### PR TITLE
log: adding support for passing string_view inline

### DIFF
--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -49,11 +49,11 @@ inline std::string now() {
 template <log_level LogLevel, typename... Args>
 struct log {
   log(const char* ctx, fmt::format_string<Args...> fmt_str,
-      const Args&&... args,
+      Args&&... args,
       std::source_location const& loc = std::source_location::current())
       : loc_{loc},
         ctx_{ctx},
-        msg_{fmt::format(fmt_str, std::forward<Args>(args)...)} {}
+        msg_{fmt::format(fmt_str, args...)} {}
 
   ~log() {
     if (LogLevel >= utl::s_verbosity) {

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -52,6 +52,15 @@ TEST(log, accept_string_view_as_extra_param) {
                            "Hello world!\n"));
 };
 
+TEST(log, accept_string_view_as_extra_param_inline) {
+  testing::internal::CaptureStderr();
+  std::string str{"world"};
+  utl::log_info("MyCtx", "Hello {}!", std::string_view{str});
+  EXPECT_THAT(testing::internal::GetCapturedStderr(),
+              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] "
+                           "Hello world!\n"));
+};
+
 TEST(log, can_have_optional_attrs) {
   testing::internal::CaptureStderr();
   utl::log_info("MyCtx", "Message").attrs({{"key", "value"}});


### PR DESCRIPTION
While working on PR https://github.com/motis-project/nigiri/pull/165 I realized that, in `nigiri` source code, we have usages like this:
```c++
scoped_timer::scoped_timer(std::string name) {
log(log_lvl::info, name_.c_str(), "starting {}", std::string_view{name_})
```
that would become:
```c++
utl::log_info(name_.c_str(), "starting {}", std::string_view{name_});
```
Currently, our logging utilities in `utl` do not support this use case.

This PR adds a unit test reproducing this case,
but so far I have to admit that I cannot find a way to have the right C++ type declarations to make it work... 😢