### PR TITLE
Log: removing 'fn' from log line format

### DIFF
--- a/include/utl/logging.h
+++ b/include/utl/logging.h
@@ -64,12 +64,11 @@ struct log {
                                       ? strrchr(loc_.file_name(), '/') + 1
                                       : loc_.file_name();
 #endif
-      fmt::print(
-          std::clog, "{time} [{level}] [{file}:{line} {fn}] [{ctx}] {msg}\n",
-          fmt::arg("time", now()), fmt::arg("level", to_str(LogLevel)),
-          fmt::arg("file", base_file_name), fmt::arg("line", loc_.line()),
-          fmt::arg("fn", loc_.function_name()), fmt::arg("ctx", ctx_),
-          fmt::arg("msg", msg_));
+      fmt::print(std::clog, "{time} [{level}] [{file}:{line}] [{ctx}] {msg}\n",
+                 fmt::arg("time", now()), fmt::arg("level", to_str(LogLevel)),
+                 fmt::arg("file", base_file_name),
+                 fmt::arg("line", loc_.line()), fmt::arg("ctx", ctx_),
+                 fmt::arg("msg", msg_));
     }
   }
 

--- a/test/logging_test.cc
+++ b/test/logging_test.cc
@@ -13,7 +13,7 @@ TEST(log, can_send_info_msg) {
   EXPECT_THAT(
       testing::internal::GetCapturedStderr(),
       MatchesRegex(
-          ".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] Message\n"));
+          ".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] Message\n"));
 }
 
 TEST(log, can_send_debug_msg) {
@@ -22,7 +22,7 @@ TEST(log, can_send_debug_msg) {
   EXPECT_THAT(
       testing::internal::GetCapturedStderr(),
       MatchesRegex(
-          ".+T.+Z \\[debug\\] \\[logging.+:.+\\] \\[MyCtx\\] Message\n"));
+          ".+T.+Z \\[debug\\] \\[logging.+:..\\] \\[MyCtx\\] Message\n"));
 }
 
 TEST(log, can_send_error_msg) {
@@ -31,7 +31,7 @@ TEST(log, can_send_error_msg) {
   EXPECT_THAT(
       testing::internal::GetCapturedStderr(),
       MatchesRegex(
-          ".+T.+Z \\[error\\] \\[logging.+:.+\\] \\[MyCtx\\] Message\n"));
+          ".+T.+Z \\[error\\] \\[logging.+:..\\] \\[MyCtx\\] Message\n"));
 }
 
 TEST(log, can_format_extra_params) {
@@ -39,7 +39,7 @@ TEST(log, can_format_extra_params) {
   auto const value = 42;
   utl::log_info("MyCtx", "String={} Int={}", "Hello", value);
   EXPECT_THAT(testing::internal::GetCapturedStderr(),
-              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] "
+              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] "
                            "String=Hello Int=42\n"));
 }
 
@@ -48,7 +48,7 @@ TEST(log, accept_string_view_as_extra_param) {
   std::string_view str{"world"};
   utl::log_info("MyCtx", "Hello {}!", str);
   EXPECT_THAT(testing::internal::GetCapturedStderr(),
-              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] "
+              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] "
                            "Hello world!\n"));
 }
 
@@ -57,7 +57,7 @@ TEST(log, accept_string_view_as_extra_param_inline) {
   std::string str{"world"};
   utl::log_info("MyCtx", "Hello {}!", std::string_view{str});
   EXPECT_THAT(testing::internal::GetCapturedStderr(),
-              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] "
+              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] "
                            "Hello world!\n"));
 }
 
@@ -67,25 +67,21 @@ TEST(log, can_have_optional_attrs) {
   EXPECT_THAT(
       testing::internal::GetCapturedStderr(),
       MatchesRegex(
-          ".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] Message\n"));
+          ".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] Message\n"));
 }
-
 
 struct dtor {
   friend std::ostream& operator<<(std::ostream& out, dtor const& x) {
     return out << x.x_;
   }
-  ~dtor() { std::clog << "DESTROY\n";}
+  ~dtor() { std::clog << "DESTROY\n"; }
   int x_;
 };
 TEST(log, temporary_streamed) {
   testing::internal::CaptureStderr();
-  auto const tmp = []() {
-    return dtor{.x_ = 9999};
-  };
+  auto const tmp = []() { return dtor{.x_ = 9999}; };
   utl::log_info("MyCtx", "{} {}", fmt::streamed(tmp()), fmt::streamed(tmp()));
-  EXPECT_THAT(
-      testing::internal::GetCapturedStderr(),
-      MatchesRegex(
-          ".+T.+Z \\[info\\] \\[logging.+:.+\\] \\[MyCtx\\] 9999 9999\nDESTROY\nDESTROY\n"));
+  EXPECT_THAT(testing::internal::GetCapturedStderr(),
+              MatchesRegex(".+T.+Z \\[info\\] \\[logging.+:..\\] \\[MyCtx\\] "
+                           "9999 9999\nDESTROY\nDESTROY\n"));
 }


### PR DESCRIPTION
Adressing those comments:
* https://github.com/motis-project/nigiri/pull/165#issuecomment-2607711689
* https://github.com/motis-project/utl/pull/27#issuecomment-2596561934

> For now, I did not include the `loc_.function_name()` in the log line,
because it can be quite long and IMHO it makes logs harder to read
without providing much valuable information.

> I think you were right with the function signature. It's cluttering output a lot. Even if it gives additional context, it's maybe not worth to clutter the text output so much.

This PR should also fix the pipeline: `clang-format-18` has been applied to `logging_test.cc`